### PR TITLE
Scroll to consent and mobile now ruled by CSS

### DIFF
--- a/cookieconsent.css
+++ b/cookieconsent.css
@@ -11,12 +11,6 @@ CORE STYLES
 	background-color: #fff !important;
 }
 
-#cc-notification.cc-mobile
-{
-	position: relative !important;
-	border-bottom: 0 !important;
-}
-
 #cc-modal #cc-modal-closebutton a,
 #cc-settingsmodal #cc-settingsmodal-closebutton a
 {
@@ -212,30 +206,7 @@ CORE STYLES
 	bottom: 16px;
 }
 
-#cc-modal.cc-mobile #cc-modal-wrapper .cc-getforsite
-{
-	position: relative !important;
-	margin-top: 30px !important;
-	margin-left: 16px;
-}
 
-#cc-modal.cc-mobile,
-#cc-settingsmodal.cc-mobile
-{
-	width: 100% !important;
-	position: relative !important;
-	top: 0 !important;
-	left: 0 !important;
-	height: auto !important;
-	z-index: 999999999999 !important;
-}
-
-#cc-modal.cc-mobile a.cc-logo,
-#cc-settingsmodal.cc-mobile a.cc-logo,
-#cc-notification.cc-mobile a.cc-logo
-{
-	display: none !important;
-}
 
 #cc-notification .cc-logo,
 #cc-tag .cc-logo,
@@ -712,29 +683,6 @@ DARK STYLE
 	top: 5px !important;
 	width: 360px !important;
 }
-#cc-notification #cc-notification-wrapper
-{
-
-}
-#cc-notification.cc-mobile #cc-notification-wrapper
-{
-	margin-right: 0 !important;
-}
-#cc-notification.cc-mobile ul.cc-notification-buttons li a,
-#cc-notification.cc-mobile ul.cc-notification-buttons li a:visited
-{
-	float: none !important;
-}
-#cc-notification.cc-mobile ul.cc-notification-buttons
-{
-	padding-top: 1px !important;
-
-	position: relative !important;
-	right: 0 !important;
-	top: 0 !important;
-	width: auto !important;
-	clear: both;
-}
 
 #cc-notification
 {
@@ -759,10 +707,6 @@ DARK STYLE
 	float: left !important;
 }
 
-#cc-notification.cc-mobile #cc-notification-permissions li
-{
-	width: auto !important;
-}
 
 #cc-notification #cc-notification-permissions li
 {
@@ -861,11 +805,6 @@ DARK STYLE
 #cc-notification h2
 {
 	margin-right: 320px !important;
-}
-
-#cc-notification.cc-mobile h2
-{
-	margin-right: 0 !important;
 }
 
 #cc-notification h2 span,
@@ -1071,7 +1010,6 @@ DARK STYLE
 
 #cc-modal #cc-modal-wrapper
 {
-	width: 686px !important;
 	margin: 40px auto !important;
 	background-color: #1d1d1d !important;
 	color: #f5f5f5 !important;
@@ -1085,6 +1023,7 @@ DARK STYLE
 	box-shadow:0px 0px 30px #000;
 	-moz-box-shadow:0px 0px 30px #000;
 	-webkit-box-shadow:0px 0px 30px #000;
+	width:686px!important;
 }
 
 #cc-modal #cc-modal-wrapper a,
@@ -1137,14 +1076,6 @@ DARK STYLE
 	width: 150px;
 }
 
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper select,
-#cc-modal.cc-mobile #cc-modal-wrapper select
-{
-	float: none !important;
-	margin-top: 10px !important;
-	position: static !important;
-}
-
 #cc-modal #cc-modal-wrapper a.cc-consentchange:hover
 {
 	background-color: #31A8F0 !important;
@@ -1165,11 +1096,6 @@ DARK STYLE
 	list-style: none !important;
 }
 
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper ul,
-#cc-modal.cc-mobile #cc-modal-wrapper ul
-{
-	padding: 0 !important;
-}
 
 #cc-settingsmodal #cc-settingsmodal-wrapper li,
 #cc-modal #cc-modal-wrapper li
@@ -1192,12 +1118,6 @@ DARK STYLE
 	font-weight: 400 !important;
 }
 
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper li strong
-#cc-modal.cc-mobile #cc-modal-wrapper li strong
-{
-	float: none !important;
-}
-
 #cc-settingsmodal #cc-settingsmodal-wrapper li span,
 #cc-modal #cc-modal-wrapper li span
 {
@@ -1212,21 +1132,10 @@ DARK STYLE
 
 }
 
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper li span,
-#cc-modal.cc-mobile #cc-modal-wrapper li span
-{
-	float: none !important;
-}
-
 #cc-settingsmodal
 {
 	font-family: 'Open Sans', Arial, Helvetica, sans-serif !important;
 	font-size: 11pt !important;
-}
-
-#cc-settingsmodal.cc-mobile
-{
-	height: auto;
 }
 
 #cc-settingsmodal #cc-settingsmodal-wrapper
@@ -1258,16 +1167,6 @@ DARK STYLE
 	height: 400px;
 	margin-top: 20px;
 }
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper
-{
-	max-height: none !important;
-}
-
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper .cc-content
-{
-	height: 540px !important;
-	max-height: none !important;
-}
 
 #cc-modal #cc-modal-wrapper p
 {
@@ -1288,11 +1187,6 @@ DARK STYLE
 	height: 420px;
 	overflow-y: auto;
 	overflow-x: hidden;
-}
-#cc-modal.cc-mobile #cc-modal-wrapper .cc-content
-{
-	height: auto !important;
-	overflow: hidden !important;
 }
 
 #cc-modal #cc-modal-wrapper h2,
@@ -1336,28 +1230,12 @@ DARK STYLE
 	margin: 16px 0 0 73px !important;
 }
 
-#cc-modal.cc-mobile #cc-modal-wrapper p.cc-subtitle
-{
-	margin-left: 0 !important;
-}
-
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper p.cc-subtitle
-{
-	margin-left: 10px !important;
-}
 
 #cc-settingsmodal #cc-settingsmodal-wrapper iframe
 {
 	width: 714px !important;
 	border: 0 !important;
 	min-height: 390px !important;
-}
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper iframe
-{
-	width: 100% !important;
-	height: 500px;
-	z-index: 9999999999999 !important;
-	margin-top: 0;
 }
 
 #cc-modal #cc-modal-closebutton a,
@@ -1413,26 +1291,6 @@ DARK STYLE
 	font-weight: 600 !important;
 }
 
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-secondclosebutton
-{
-	padding-left: 10px;
-	padding-top: 0;
-}
-
-#cc-modal.cc-mobile #cc-modal-secondclosebutton a,
-#cc-modal.cc-mobile #cc-modal-secondclosebutton a:visited,
-#cc-modal.cc-mobile #cc-modal-global a,
-#cc-modal.cc-mobile #cc-modal-global a:visited
-{
-	float: none !important;
-}
-
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-secondclosebutton a,
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-secondclosebutton a:visited
-{
-	display: none !important;
-}
-
 #cc-modal #cc-modal-secondclosebutton a:hover,
 #cc-modal #cc-modal-secondclosebutton a:active,
 #cc-settingsmodal #cc-settingsmodal-secondclosebutton a:hover,
@@ -1446,8 +1304,6 @@ DARK STYLE
 
 }
 
-
-
 #cc-modal #cc-modal-wrapper #cc-modal-footer-buttons
 {
 	margin-left: 57px !important;
@@ -1458,15 +1314,6 @@ DARK STYLE
 {
 	margin-left: 72px !important;
 }
-
-#cc-modal.cc-mobile #cc-modal-wrapper #cc-modal-footer-buttons
-{
-	position:relative;
-	width: auto;
-	padding-top: 10px !important;
-	margin-left: 0 !important;
-}
-
 
 #cc-modal #cc-modal-wrapper .cc-preference-importantmessage
 {
@@ -1528,60 +1375,225 @@ DARK STYLE
 	color: #FFF !important;
 }
 
-#cc-modal.cc-mobile #cc-modal-wrapper
-{
-	height: auto !important;
-	max-height: none !important;
-	min-height: inherit !important;
-}
-
-#cc-modal.cc-mobile #cc-modal-wrapper,
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper
-{
-	margin-top: 0 !important;
-	width: auto !important;
-}
-#cc-modal.cc-mobile #cc-modal-wrapper h2
-{
-	width: auto !important;
-	margin-left: 0 !important;
-}
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper h2 span,
-#cc-modal.cc-mobile #cc-modal-wrapper h2 span
-{
-	display: block;
-	margin-top: 8px;
-}
-
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper h2
-{
-	margin-left: 10px !important;
-	width: auto !important;
-}
-
-#cc-modal.cc-mobile #cc-modal-wrapper,
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper
-{
-	border: 0 !important;
-	box-shadow: none;
-	-moz-box-shadow: none;
-	-webkit-box-shadow: none;
-	background-image: none !important;
-	max-height: none !important;
-
-}
-#cc-settingsmodal.cc-mobile #cc-settingsmodal-wrapper li span,
-#cc-modal.cc-mobile #cc-modal-wrapper li span
-{
-	width: auto !important;
-	float: none !important;
-}
-#cc-modal.cc-mobile #cc-modal-wrapper a.cc-consentchange
-{
-	margin-top: 10px !important;
-	float: none !important;
-}
 #cc-modal #cc-modal-wrapper li strong
 {
 	width: auto !important;
+}
+
+
+/**********    		MOBILE         ***********/
+
+
+@media screen and (max-width: 730px) {
+	#cc-notification
+	{
+		border-bottom: 0!important;
+		max-height: 100%!important;
+		overflow: scroll!important;
+	}
+
+	#cc-modal #cc-modal-wrapper .cc-getforsite
+	{
+		position: relative !important;
+		margin-top: 30px !important;
+		margin-left: 16px;
+	}
+
+	#cc-modal,
+	#cc-settingsmodal
+	{
+		width: 100% !important;
+		position: fixed !important;
+		top: 0 !important;
+		left: 0 !important;
+		max-height: 100% !important;
+		z-index: 999999999999 !important;
+
+	}
+
+	#cc-modal a.cc-logo,
+	#cc-settingsmodal a.cc-logo,
+	#cc-notification a.cc-logo
+	{
+		display: none !important;
+	}
+
+	#cc-notification #cc-notification-wrapper
+	{
+		margin-right: 0 !important;
+		padding: 20px 32px!important;
+	}
+
+	#cc-notification ul.cc-notification-buttons li a,
+	#cc-notification ul.cc-notification-buttons li a:visited
+	{
+		float: none !important;
+	}
+	#cc-notification ul.cc-notification-buttons
+	{
+		padding-top: 1px !important;
+		position: relative !important;
+		right: 0 !important;
+		top: 0 !important;
+		width: auto !important;
+		clear: both;
+	}
+	#cc-notification #cc-notification-permissions li
+	{
+		width: auto !important;
+	}
+
+	#cc-notification h2
+	{
+		margin-right: 0 !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper select,
+	#cc-modal #cc-modal-wrapper select
+	{
+		float: none !important;
+		margin-top: 10px !important;
+		position: static !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper li strong
+	#cc-modal #cc-modal-wrapper li strong
+	{
+		float: none !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper li span,
+	#cc-modal #cc-modal-wrapper li span
+	{
+		float: none !important;
+	}
+
+	#cc-settingsmodal
+	{
+		height: auto;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper
+	{
+		max-height: none !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper .cc-content
+	{
+		height: 540px !important;
+		max-height: none !important;
+	}
+
+	#cc-modal #cc-modal-wrapper .cc-content
+	{
+		height: auto !important;
+		overflow: hidden !important;
+	}
+
+	#cc-modal #cc-modal-wrapper p.cc-subtitle
+	{
+		margin-left: 0 !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper p.cc-subtitle
+	{
+		margin-left: 10px !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper iframe
+	{
+		width: 100% !important;
+		height: 500px;
+		z-index: 9999999999999 !important;
+		margin-top: 0;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-secondclosebutton
+	{
+		padding-left: 10px;
+		padding-top: 0;
+	}
+
+	#cc-modal #cc-modal-secondclosebutton a,
+	#cc-modal #cc-modal-secondclosebutton a:visited,
+	#cc-modal #cc-modal-global a,
+	#cc-modal #cc-modal-global a:visited
+	{
+		float: none !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-secondclosebutton a,
+	#cc-settingsmodal #cc-settingsmodal-secondclosebutton a:visited
+	{
+		display: none !important;
+	}
+
+	#cc-modal #cc-modal-wrapper #cc-modal-footer-buttons
+	{
+		position:relative;
+		width: auto;
+		padding-top: 10px !important;
+		margin-left: 0 !important;
+	}
+
+	#cc-modal #cc-modal-wrapper
+	{
+		height: auto !important;
+		max-height: none !important;
+		min-height: inherit !important;
+	}
+
+	#cc-modal #cc-modal-wrapper,
+	#cc-settingsmodal #cc-settingsmodal-wrapper
+	{
+		margin-top: 0 !important;
+		width: auto !important;
+	}
+	#cc-modal #cc-modal-wrapper h2
+	{
+		width: auto !important;
+		margin-left: 0 !important;
+	}
+	#cc-settingsmodal #cc-settingsmodal-wrapper h2 span,
+	#cc-modal #cc-modal-wrapper h2 span
+	{
+		display: block;
+		margin-top: 8px;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper h2
+	{
+		margin-left: 10px !important;
+		width: auto !important;
+	}
+
+	#cc-modal #cc-modal-wrapper,
+	#cc-settingsmodal #cc-settingsmodal-wrapper
+	{
+		border: 0 !important;
+		box-shadow: none;
+		-moz-box-shadow: none;
+		-webkit-box-shadow: none;
+		background-image: none !important;
+		max-height: none !important;
+
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper ul,
+	#cc-modal #cc-modal-wrapper ul
+	{
+		padding: 0 !important;
+	}
+
+	#cc-settingsmodal #cc-settingsmodal-wrapper li span,
+	#cc-modal #cc-modal-wrapper li span
+	{
+		width: auto !important;
+		float: none !important;
+	}
+	#cc-modal #cc-modal-wrapper a.cc-consentchange
+	{
+		margin-top: 10px !important;
+		float: none !important;
+	}
 }

--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -20,14 +20,12 @@ var cc =
     version: '1.0.10',
     jqueryversionrequired: '1.4.4',
     initobj: false,
-    ismobile: false,
     setupcomplete: false,
     allasked: false,
     checkedlocal: false,
     checkedremote: false,
     remoteresponse: false,
     frommodal: false,
-    hassetupmobile: false,
     sessionkey: false,
     noclosewin: false,
     closingmodal: false,
@@ -77,7 +75,8 @@ var cc =
         refreshOnConsent: false,
         style: "dark",
         bannerPosition: "top",
-        clickAnyLinkToConsent: false,
+        clickAnyLinkToConsent: true,
+        scrollToConsent: true,
         privacyPolicy: false,
         collectStatistics: false,
         tagPosition: 'bottom-right',
@@ -342,11 +341,6 @@ var cc =
                 params += ":" + value.statsid;
             }
         });
-        if (cc.ismobile) {
-            params += "&m=1";
-        } else {
-            params += "&m=0";
-        }
         params += "&u=" + encodeURIComponent(document.URL);
         return params;
     },
@@ -438,7 +432,7 @@ var cc =
     },
 
     reloadifnecessary: function () {
-        if (cc.settings.refreshOnConsent || cc.ismobile || cc.forcereload) {
+        if (cc.settings.refreshOnConsent || cc.forcereload) {
             setTimeout("location.reload(true);", 50);
         }
     },
@@ -469,11 +463,6 @@ var cc =
             jQuery(this).remove();
         });
         jQuery('#cc-notification').remove();
-        if (cc.ismobile) {
-            cc.setupformobile();
-            jQuery('head').append('<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">');
-            jQuery('body').html('').css("margin", 0);
-        }
         data = '<div id="cc-notification">' +
             '<div id="cc-notification-wrapper">' +
             '<h2><span>' + cc.strings.notificationTitle + '</span></h2>' +
@@ -510,9 +499,6 @@ var cc =
         jQuery('#cc-notification').addClass(cc.settings.style).addClass(cc.settings.bannerPosition);
         bannerh = jQuery('#cc-notification').height();
         jQuery('#cc-notification').hide();
-        if (cc.ismobile) {
-            jQuery('#cc-notification').addClass("cc-mobile");
-        }
         jQuery('#cc-notification-permissions').prepend('<ul></ul>');
         allcustom = true;
         jQuery.each(cc.cookies, function (key, value) {
@@ -580,19 +566,14 @@ var cc =
             jQuery(this).blur();
             return false;
         });
-
-        if (!cc.ismobile) {
-            if (cc.settings.bannerPosition == "cc-push") {
-                jQuery('html').animate({marginTop: bannerh}, 400);
-            }
-            jQuery('#cc-notification').slideDown();
-        } else {
-            jQuery('#cc-notification').show();
-        }
+        jQuery('#cc-notification').show();
 
         jQuery('#cc-approve-button-thissite').click(cc.onlocalconsentgiven);
         if (cc.settings.clickAnyLinkToConsent) {
             jQuery("a").filter(':not(.cc-link)').click(cc.onlocalconsentgiven);
+        }
+        if(cc.settings.scrollToConsent) {
+            jQuery(window).on('mousewheel DOMMouseScroll wheel', cc.onlocalconsentgiven);
         }
         if (allcustom) {
             jQuery('#cc-notification h2 span').html(cc.strings.customCookie);
@@ -793,6 +774,9 @@ var cc =
         if (cc.settings.clickAnyLinkToConsent) {
             jQuery("a").filter(':not(.cc-link)').unbind("click");
         }
+        if (cc.settings.scrollToConsent) {
+            jQuery(window).unbind('mousewheel DOMMouseScroll wheel');
+        }
         cc.allagree = true;
         jQuery.each(cc.cookies, function (key, value) {
             if (!value.approved && !value.asked) {
@@ -830,14 +814,6 @@ var cc =
         }
         cc.reloadkey = true;
         cc.insertscript(urlx);
-
-        if (!cc.ismobile) {
-            jQuery('#cc-notification').slideUp();
-            if (cc.settings.bannerPosition == "cc-push") {
-                //detect body margin
-                jQuery('html').animate({marginTop: 0}, 400);
-            }
-        }
         cc.checkapproval();
 
         return false;
@@ -867,6 +843,9 @@ var cc =
             if (cc.settings.clickAnyLinkToConsent) {
                 jQuery("a").filter(':not(.cc-link)').unbind("click");
             }
+            if (cc.settings.scrollToConsent) {
+                jQuery(window).unbind('mousewheel DOMMouseScroll wheel');
+            }
             jQuery.each(cc.cookies, function (key, value) {
                 if (!value.approved && !value.asked) {
                     if (enableall || jQuery('#cc-checkbox-' + key).is(':checked')) {
@@ -886,12 +865,10 @@ var cc =
             cc.forcereload = true;
         }
 
-        if (!cc.ismobile) {
-            jQuery('#cc-notification').slideUp();
-            if (cc.settings.bannerPosition == "cc-push") {
-                //detect body margin
-                jQuery('html').animate({marginTop: 0}, 400);
-            }
+        jQuery('#cc-notification').slideUp();
+        if (cc.settings.bannerPosition == "cc-push") {
+            //detect body margin
+            jQuery('html').animate({marginTop: 0}, 400);
         }
         cc.checkapproval();
         cc.reloadifnecessary();
@@ -940,9 +917,6 @@ var cc =
         jQuery(document).bind('keyup', cc.onkeyup);
         jQuery('body').prepend('<div id="cc-modal-overlay"></div>');
         jQuery(this).blur();
-        if (cc.ismobile) {
-            cc.setupformobile();
-        }
         data = '<div id="cc-modal">' +
             '<div id="cc-modal-wrapper">' +
             '<h2>' + cc.strings.privacySettingsDialogTitleA + ' <span>' + cc.strings.privacySettingsDialogTitleB + '</span></h2>' +
@@ -966,9 +940,6 @@ var cc =
             jQuery('#cc-modal-global').hide();
         }
         jQuery('#cc-modal').addClass(cc.settings.style).click(cc.closemodals);
-        if (cc.ismobile) {
-            jQuery('#cc-modal').addClass("cc-mobile");
-        }
         cc.reloadmodal();
         jQuery('#cc-modal').fadeIn();
         jQuery('#cc-modal-overlay').fadeIn();
@@ -1068,11 +1039,7 @@ var cc =
                 cc.closingmodal = false;
             });
         }
-        if (cc.ismobile) {
-            jQuery('#cc-modal').toggle();
-        } else {
-            jQuery('#cc-modal').fadeToggle();
-        }
+        jQuery('#cc-modal').fadeToggle();
         return false;
     },
 
@@ -1188,10 +1155,6 @@ var cc =
             cc.showhidemodal();
         }
         jQuery(this).blur();
-        if (cc.ismobile) {
-            cc.setupformobile();
-            jQuery('#cc-notification').remove();
-        }
         if (cc.frommodal) {
             buttontext = cc.strings.backToSiteSettings;
         } else {
@@ -1218,26 +1181,10 @@ var cc =
         jQuery('#cc-settingsmodal-wrapper').click(function () {
             cc.noclosewin = true;
         });
-        if (cc.ismobile) {
-            jQuery('#cc-settingsmodal').addClass("cc-mobile");
-        }
         jQuery('#cc-settingsmodal').fadeIn();
         jQuery('.cc-settingsmodal-closebutton').click(cc.closepreferencesmodal);
 
         return false;
-    },
-
-    setupformobile: function () {
-        if (!cc.hassetupmobile) {
-            cc.hassetupmobile = true;
-            jQuery('head').append('<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">');
-            if (cc.settings.style == 'cc-light') {
-                bgcol = '#e1e1e1';
-            } else {
-                bgcol = '#1d1d1d'
-            }
-            jQuery('body').html('').css("margin", 0).css('width', 'auto').css("backgroundColor", bgcol).css("backgroundImage", 'none');
-        }
     },
 
     onfirstload: function () {
@@ -1284,17 +1231,6 @@ if (!(window.jQuery)) {
 } else {
     jQuery(document).ready(cc.onfirstload);
 }
-
-/**
- * jQuery.browser.mobile (http://detectmobilebrowser.com/)
- *
- * jQuery.browser.mobile will be true if the browser is a mobile device - modified so that cc.ismobile is true
- *
- **/
-(function (a) {
-    cc.ismobile = /android.+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|e\-|e\/|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(di|rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|xda(\-|2|g)|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))
-})(navigator.userAgent || navigator.vendor || window.opera);
-
 
 /**
  * Load web font


### PR DESCRIPTION
Removed all the jquery rules for mobile, included user agent sniffing that isn't reliable. Added a scrollToConsent setting, because it's enough to have consent to install cookies. I wanted also to create a "Click any link to consent" function, but I notice it's already there, so I put it on "true" by default.

The script used to do user agent sniffing for mobile devices, then to add a class of cc-mobile to the cc-modal. Now, I took every mobile rules and added that under a media query for small devices. I needed also to add few rules for adjusting interactions, because there was problem of window scrolling.
